### PR TITLE
Adding range config to finder, to specify range for selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This extension contributes the following settings:
 * `aceJump.placeholder.color`: placeholder background color; defaults to black
 * `aceJump.placeholder.border`: placeholder background color; defaults to dotted thin black
 * `aceJump.finder.pattern`: regex pattern for the matching word separators; pattern should represent the single character which can split a word, for example a dot, or a square; defaults to `[ ,-.{_(\\[]`
- 
+* `aceJump.finder.range`: if no selection is made, maximum number of lines from the active cursors' line which should be considered for a match
+
 ### 1.0.0
 
 Initial release

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
         "aceJump.finder.pattern": {
           "type": "string",
           "default": "[ ,-.{_(\\[]"
+        },
+        "aceJump.finder.range": {
+          "type": "number",
+          "default": "40"
         }
       }
     }

--- a/src/acejump.ts
+++ b/src/acejump.ts
@@ -59,6 +59,7 @@ export class AceJump {
         this.config.placeholder.border = config.get<string>("placeholder.border");
 
         this.config.finder.pattern = config.get<string>("finder.pattern");
+        this.config.finder.range = config.get<number>("finder.range");
 
         this.placeholderCalculus.load(this.config);
         this.placeHolderDecorator.load(this.config);
@@ -143,10 +144,10 @@ export class AceJump {
             }
         }
         else {
-            selection.text = editor.document.getText();
+            selection.startLine = Math.max(editor.selection.active.line - this.config.finder.range, 0);
+            selection.lastLine = Math.min(editor.selection.active.line + this.config.finder.range, editor.document.lineCount);
 
-            selection.startLine = 0;
-            selection.lastLine = editor.document.lineCount;
+            selection.text = editor.document.getText(new vscode.Range(selection.startLine, 0, selection.lastLine, 0));
         }
 
         return selection;

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,4 +13,5 @@ class PlaceHolderConfig {
 
 class FinderConfig {
     pattern: string;
+    range: number;
 }


### PR DESCRIPTION
In lieu of the vscode's absent API to get the visible lines. I'm suggesting a config that take n number of lines to and from the active line when searching for selections.

Of course, this can be phased out when the appropriate API on vscode is made available.

Somewhat mitigates #5.