### PR TITLE
Resolve non-intuitive behavior when search query matches separator regex

### DIFF
--- a/src/acejump.ts
+++ b/src/acejump.ts
@@ -211,13 +211,14 @@ export class AceJump {
         char = char.toLowerCase();
 
         let indices = [];
+        const finderPatternRegex = new RegExp(this.config.finder.pattern);
 
-        if (this.config.finder.onlyInitialLetter) {
+        if (this.config.finder.onlyInitialLetter && !finderPatternRegex.test(char)) {
             //current line index
             let index = 0;
 
             //splitted by the pattern 
-            let words = str.split(new RegExp(this.config.finder.pattern));
+            let words = str.split(finderPatternRegex);
             for (var w = 0; w < words.length; w++) {
 
                 if (words[w][0] && words[w][0].toLowerCase() === char) {


### PR DESCRIPTION
Currently CodeAceJumper defaults to matching against first character of each word. 

However the implementation (splitting by a separator regex and then matching first char of words) results in very non-intuitive behavior when I try to search for something that matches the regex. Eg. I tried to search for a quote (") and it returned no matches in my package.json which was very bizarre.

The default behavior (aceJump.finder.onlyInitialLetter = true) is what I want 90% of the cases, but the way it is implemented does not make sense when searching for (quotes, underscore, bracket etc.). I can set onlyInitialLetter as false, but that requires a lot of typing for normal usage. 

So I propose that when user is searching for one of the separator characters, we don't use the logic for matching only initial letters (irrespective of user configuration) because it will anyways yield no results and fallback to full searching all characters (which results in what a user would intuitively expect).