### PR TITLE
Escape char for RegExp. fixes #34

### DIFF
--- a/src/area-index-finder.ts
+++ b/src/area-index-finder.ts
@@ -109,7 +109,8 @@ export class AreaIndexFinder {
         index += words[w].length + 1;
       }
     } else {
-      const regexp = new RegExp(`[${char}]`, 'gi');
+      const escapedChar = char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regexp = new RegExp(escapedChar, 'gi');
       let match: RegExpMatchArray | null;
       // tslint:disable-next-line:no-conditional-assignment
       while ((match = regexp.exec(line)) !== null) {


### PR DESCRIPTION
Reason seems to be that somehow
```ts
RegExp('[[]', 'gi').exec("[]")
```
creates a match, while
```ts
RegExp('[]]', 'gi').exec("[]")
```
doesn't.
In practice, I guess any special character should be escaped before inserted into the RegExp.
I took the replace function [from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping), but there's also lodash [escapeRegExp](https://lodash.com/docs#escapeRegExp) if you prefer that.