### PR TITLE
Add extensionKind to package.json, fixes #153

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,10 @@
     "*"
   ],
   "main": "./dist/extension",
+  "extensionKind": [
+    "workspace",
+    "ui"
+  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
Putting it in this order (first `workspace`, then `ui`) should actually not change anything when it is run locally and only switch to `ui mode` when run remotely.
Another installation on the remote system should then not be necessary anymore.