### PR TITLE
Add config 'includeEndCharInSelection', fixes #110

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
           "type": "boolean",
           "default": true
         },
+        "aceJump.finder.includeEndCharInSelection": {
+          "type": "boolean",
+          "default": true
+        },
         "aceJump.dim.enabled": {
           "type": "boolean",
           "default": true

--- a/src/acejump.ts
+++ b/src/acejump.ts
@@ -75,12 +75,14 @@ export class AceJump {
             JumpKind.Normal,
           );
 
+          const isBackwardJump = editor.selection.active.line > placeholder.line || editor.selection.active.character > placeholder.character;
+          const offset = isBackwardJump || !workspace.getConfiguration('aceJump').finder.includeEndCharInSelection ? 0 : 1;
           editor.selection = new Selection(
             new Position(
               editor.selection.active.line,
               editor.selection.active.character,
             ),
-            new Position(placeholder.line, placeholder.character + 1),
+            new Position(placeholder.line, placeholder.character + offset),
           );
 
           await this.jumper.scrollToLine(placeholder.line);

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -64,6 +64,7 @@ export function buildConfig(cfg: WorkspaceConfiguration) {
     pattern: cfg.get('finder.pattern', `[ ,-.{_(\"'<\\[\t]`),
     skipSelection: cfg.get('finder.skipSelection', false),
     onlyInitialLetter: cfg.get('finder.onlyInitialLetter', true),
+    includeEndCharInSelection: cfg.get('finder.includeEndCharInSelection', true),
   };
 
   config.dim = {

--- a/src/config/finder-config.ts
+++ b/src/config/finder-config.ts
@@ -2,4 +2,5 @@ export class FinderConfig {
   public pattern = `[ ,-.{_(\"'<\\[\t]`;
   public skipSelection = false;
   public onlyInitialLetter = true;
+  public includeEndCharInSelection = true;
 }


### PR DESCRIPTION
This should fix #110 where the selection for a backwards jump does not include the first character.

Furthermore, it adds an additional setting `includeEndCharInSelection` which is, by default, `true`. This keeps the current behavior that for a forward jump the jumped-to character is *included* in the selection.

Since this behavior could depend on personal preference, you can set the option to `false` which means the selection ends *before* the jumped-to character.

I did not add any documentation. As a "reminder" I will open another issue which suggests documenting all settings.