### PR TITLE
Direct switch from char to line jump mode and new setting 'jumpToLineEndings'

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,10 @@
             "top"
           ],
           "default": "center"
+        },
+        "aceJump.finder.jumpToLineEndings": {
+          "type": "boolean",
+          "default": false
         }
       }
     }

--- a/src/acejump.ts
+++ b/src/acejump.ts
@@ -1,8 +1,6 @@
 import {
   commands,
   ExtensionContext,
-  Position,
-  Selection,
   workspace,
 } from 'vscode';
 import { buildConfig } from './config/config';
@@ -16,16 +14,7 @@ export class AceJump {
     context.subscriptions.push(
       commands.registerCommand('extension.aceJump', async () => {
         try {
-          const { editor, placeholder } = await this.jumper.jump(
-            JumpKind.Normal,
-          );
-
-          editor.selection = new Selection(
-            new Position(placeholder.line, placeholder.character),
-            new Position(placeholder.line, placeholder.character),
-          );
-
-          await this.jumper.scrollToLine(placeholder.line);
+          await this.jumper.jump(JumpKind.Normal, false);
 
           // tslint:disable-next-line:no-empty
         } catch (_) {}
@@ -35,57 +24,29 @@ export class AceJump {
     context.subscriptions.push(
       commands.registerCommand('extension.aceJump.multiChar', async () => {
         try {
-          const { editor, placeholder } = await this.jumper.jump(
-            JumpKind.MultiChar,
-          );
-
-          editor.selection = new Selection(
-            new Position(placeholder.line, placeholder.character),
-            new Position(placeholder.line, placeholder.character),
-          );
-
-          await this.jumper.scrollToLine(placeholder.line);
+          await this.jumper.jump(JumpKind.MultiChar, false);
 
           // tslint:disable-next-line:no-empty
         } catch (_) {}
       }),
     );
 
-      context.subscriptions.push(
-        commands.registerCommand('extension.aceJump.line', async () => {
-          try {
-            const { editor, placeholder } = await this.jumper.jumpToLine();
-  
-            editor.selection = new Selection(
-              new Position(placeholder.line, placeholder.character),
-              new Position(placeholder.line, placeholder.character),
-            );
-  
-            await this.jumper.scrollToLine(placeholder.line);
-  
-            // tslint:disable-next-line:no-empty
-          } catch (_) {}
-        }),
-      );
+    context.subscriptions.push(
+      commands.registerCommand('extension.aceJump.line', async () => {
+        try {
+          // if we interrupt a jump (isJumping still true), re-use its selectionMode
+          const selectionMode = this.jumper.isJumping ? null : false;
+          await this.jumper.jumpToLine(selectionMode);
+
+          // tslint:disable-next-line:no-empty
+        } catch (_) {}
+      }),
+    );
 
     context.subscriptions.push(
       commands.registerCommand('extension.aceJump.selection', async () => {
         try {
-          const { editor, placeholder } = await this.jumper.jump(
-            JumpKind.Normal,
-          );
-
-          const isBackwardJump = editor.selection.active.line > placeholder.line || editor.selection.active.character > placeholder.character;
-          const offset = isBackwardJump || !workspace.getConfiguration('aceJump').finder.includeEndCharInSelection ? 0 : 1;
-          editor.selection = new Selection(
-            new Position(
-              editor.selection.active.line,
-              editor.selection.active.character,
-            ),
-            new Position(placeholder.line, placeholder.character + offset),
-          );
-
-          await this.jumper.scrollToLine(placeholder.line);
+          await this.jumper.jump(JumpKind.Normal, true);
 
           // tslint:disable-next-line:no-empty
         } catch (_) {}

--- a/src/area-index-finder.ts
+++ b/src/area-index-finder.ts
@@ -82,16 +82,23 @@ export class AreaIndexFinder {
    * @param area
    */
   public findByLines(
+    editor: TextEditor,
     area: JumpArea
   ): LineIndexes {
     const lineIndexes = new LineIndexes();
 
     for (const areaLine of area.lines) {
       for (let i = areaLine[0]; i <= areaLine[1]; i++) {
-
-        lineIndexes.count = 1;
-        // always first visible character!
-        lineIndexes.indexes[i] = [0];
+        const endIndex = editor.document.lineAt(i).range.end.character;
+        if (this.config.finder.jumpToLineEndings && endIndex > 0) {
+          lineIndexes.count = 2;
+          // add beginning and end of line
+          lineIndexes.indexes[i] = [0, endIndex];
+        } else {
+          lineIndexes.count = 1;
+          // always first visible character!
+          lineIndexes.indexes[i] = [0];
+        }
       }
     }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -65,6 +65,7 @@ export function buildConfig(cfg: WorkspaceConfiguration) {
     skipSelection: cfg.get('finder.skipSelection', false),
     onlyInitialLetter: cfg.get('finder.onlyInitialLetter', true),
     includeEndCharInSelection: cfg.get('finder.includeEndCharInSelection', true),
+    jumpToLineEndings: cfg.get('finder.jumpToLineEndings', true),
   };
 
   config.dim = {

--- a/src/config/finder-config.ts
+++ b/src/config/finder-config.ts
@@ -3,4 +3,5 @@ export class FinderConfig {
   public skipSelection = false;
   public onlyInitialLetter = true;
   public includeEndCharInSelection = true;
+  public jumpToLineEndings = false;
 }

--- a/src/inline-input.ts
+++ b/src/inline-input.ts
@@ -97,7 +97,7 @@ export class InlineInput {
     }
   };
 
-  private cancel = () => {
+  public cancel = () => {
     this.cancelWithReason(CancelReason.Cancel);
   };
 

--- a/src/jumper.ts
+++ b/src/jumper.ts
@@ -278,7 +278,7 @@ export class Jumper {
     return new Promise<Placeholder>(async (resolve, reject) => {
       const area = this.jumpAreaFinder.findArea(editor);
 
-      const lineIndexes = this.areaIndexFinder.findByLines(area);
+      const lineIndexes = this.areaIndexFinder.findByLines(editor, area);
 
       if (lineIndexes.count <= 0) {
         reject(CancelReason.NoMatches);


### PR DESCRIPTION
This implements essentially the points brought up in [this comment](https://github.com/lucax88x/CodeAceJumper/issues/162#issuecomment-587860973).

Please review it carefully, I had to make some bigger changes.

I moved the whole `editor.selection` logic which was previously in `acejump.ts` (e.g. in `commands.registerCommand('extension.aceJump', ...`) into `Jumper.jump()` resp. `Jumper.jumpToLine()` and added a new boolean parameter there.

I needed to make `InlineInput.cancel()` and `Jumper.isJumping` public.

I removed the "lock" `if (!!this.isJumping)` from `Jumper.jumpToLine()` and replaced it with a `InlineInput.cancel()` so that any blocking inputs from previous jumps should be gone.

Finally, I added the setting `jumpToLineEndings` (false by default) to show decorations at the end of lines. This was necessary for me, as it allows to select to end of line when the other new setting `includeEndCharInSelection` is false.

**Important:**
* some tests are failing now since I didn't adapt them to the new signatures of `Jumper.jump()` and `Jumper.jumpToLine()`
* I did not test behavior with multiChar selection

This is still TODO. I just wanted to let you know that the functionality is basically there so you don't start re-implementing it by yourself.