### PR TITLE
Fix wrong multichar order at line end, closes #228

### DIFF
--- a/src/placeholder-decorator.ts
+++ b/src/placeholder-decorator.ts
@@ -37,9 +37,11 @@ export class PlaceHolderDecorator {
           new Position(placeholder.line, lineLength),
           new Position(placeholder.line, lineLength + 1),
         );
-        // if a placeholder already exists at line-end, concat the placeholder chars
+        // if a placeholder already exists at line-end, add the new char
+        // at the correct offset (creating a multi-char placeholder)
         if (!!this.lineEndDecorations[placeholder.line]) {
-          placeholderChar += this.lineEndDecorations[placeholder.line][0];
+          const phCharPrevious = this.lineEndDecorations[placeholder.line][0];
+          placeholderChar = [phCharPrevious.slice(0, offset), placeholderChar, phCharPrevious.slice(offset)].join('')
           this.lineEndDecorations[placeholder.line][1].dispose();
         }
       }


### PR DESCRIPTION
When creating a 2-char placeholder, instead of always inserting the new char at the beginning, the new char needed to be inserted at index `offset`.